### PR TITLE
GUI setup in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+RUN apt-get install libegl1-mesa-dev libgles2-mesa-dev libmirclient-dev libxkbcommon-dev libsdl2-dev -y
+
+WORKDIR /srv/ai-sim

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# Just to make sure the GUI is accessable from the host machine
+docker-gui:
+	@xhost +local:root
+	@docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  ascend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ./run_gui.sh
+    environment:
+      DISPLAY:
+    devices:
+      - /dev/dri
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - .:/srv/ai-sim/:rw
+    working_dir: /srv/ai-sim

--- a/run_gui.sh
+++ b/run_gui.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd build
+g++ ../gui.cpp -o sim -lGL `sdl2-config --cflags --libs`
+./sim


### PR DESCRIPTION
Run `make docker-gui` to fix initial setup and run.

This PR may only work on ubuntu machines with `docker-compose` installed.