### PR TITLE
fix 180degree turn direction (now turning clockwise)

### DIFF
--- a/sim.h
+++ b/sim.h
@@ -511,8 +511,8 @@ ReverseStart(robot_Event event,
              robot_Internal *internal,
              robot_Action *action)
 {
-    action->left_wheel = -Robot_Speed / 2.0f;
-    action->right_wheel = Robot_Speed / 2.0f;
+    action->left_wheel = Robot_Speed / 2.0f;
+    action->right_wheel = -Robot_Speed / 2.0f;
     action->red_led = 1;
     internal->begin_reverse = event.elapsed_time;
 }


### PR DESCRIPTION
Ground robot is now turning clockwise when doing a 180degree turn